### PR TITLE
Added Instancing support through CLAs and ENV.

### DIFF
--- a/StarMap.Core/ModRepository/ModLoader.cs
+++ b/StarMap.Core/ModRepository/ModLoader.cs
@@ -1,6 +1,7 @@
 ﻿using KSA;
 using StarMap.API;
 using StarMap.Core.Config;
+using StarMap.Core.Patches;
 using System.Reflection;
 using System.Runtime.Loader;
 using Tomlet;
@@ -44,6 +45,7 @@ namespace StarMap.Core.ModRepository
 
         public void Init()
         {
+            DocumentsPathPatches.Apply();
             PrepareMods();
         }
 
@@ -60,7 +62,7 @@ namespace StarMap.Core.ModRepository
             {
                 if (!mod.Enabled)
                 {
-                    Console.WriteLine($"StarMap - Not loading mod: {mod.Id} because it is disable in manifest");
+                    Console.WriteLine($"StarMap - Not loading mod: {mod.Id} because it is disabled in manifest");
                     continue;
                 }
 

--- a/StarMap.Core/Patches/DocumentsPathPatches.cs
+++ b/StarMap.Core/Patches/DocumentsPathPatches.cs
@@ -1,0 +1,47 @@
+﻿using HarmonyLib;
+using KSA;
+
+namespace StarMap.Core.Patches
+{
+    internal static class DocumentsPathPatches
+    {
+        private const string CliFlag = "-InstancePath";
+        private const string EnvVarName = "INSTANCE_PATH";
+        private const string HarmonyId = "com.starmap.core.documentspathoverride";
+
+        public static void Apply()
+        {
+            // Check if an override path is provided via command-line argument or environment variable
+            var overridePath = TryGetOverride();
+            if (string.IsNullOrEmpty(overridePath))
+                return;
+
+            // Apply the Harmony patch to override the DocumentsFolderPath property
+            var harmony = new Harmony(HarmonyId);
+            var original = AccessTools.PropertyGetter(typeof(Constants), nameof(Constants.DocumentsFolderPath));
+            var prefix = new HarmonyMethod(typeof(DocumentsPathPatches), nameof(Prefix));
+            harmony.Patch(original, prefix: prefix);
+            Console.WriteLine($"StarMap - Using Instance Path: {overridePath}");
+        }
+
+        private static bool Prefix(ref string __result)
+        {
+            __result = TryGetOverride()!;
+            return false;
+        }
+
+        private static string? TryGetOverride()
+        {
+            var args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (string.Equals(args[i], CliFlag, StringComparison.OrdinalIgnoreCase))
+                {
+                    return args[i + 1];
+                }
+            }
+
+            return Environment.GetEnvironmentVariable(EnvVarName);
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to switch which directory StarMap looks at for the manifest and mod loading. Also redirects KSA to the new instance folder.

You can now select which folder you want StarMap and KSA to look at for things like `manifest.toml`, `\mods`, `settings.toml`, `\saves`, `\vehicles`, `\logs`, `\crashdumps`, `\HUDLayouts`, etc.

This can be done either by using a Command Line Argument -> `.\StarMap.exe -InstancePath "C:\users\<user>\OneDrive\Documents\My Games\Instance A"` and StarMap, KSA, and all mods (as long as the mods use `Constants.DocumentFolderPath` or other variables/functions that derive from that) will now read/write to the new instance folder.

The other option is be setting the file path you want in an Environment Variable when launching StarMap. -> `$env:INSTANCE_PATH = "C:\Users\<user>\OneDrive\Documents\My Games\Instance A"; .\StarMap.exe` (this is for power shell).

This modification is done through a Harmony Patch of the `Constants.DocumentsFolderPath` getter which flows down to all relevant use cases that involve the `Documents\My Games\Kitten Space Agency\` folder, and only provides the newly given path if it exists, otherwise it falls back to KSA's default getter.

!!DISCLAIMER!! - if you provide an illegal or non-existing path for instancing when launching StarMap, StarMap and KSA will both crash as there are no checks for if the path exists. This is an intended behavior as the program or user who is creating an instance should have the instance's directory made before launching.