### PR TITLE
Add StarMapAfterSave and StarMapAfterLoad hooks

### DIFF
--- a/StarMap.API/README.md
+++ b/StarMap.API/README.md
@@ -220,3 +220,31 @@ Methods marked with this attribute will be called after `KSA.Program.OnFrame` is
 [StarMapAfterOnFrame]
 public void ModMethod(double currentPlayerTime, double dtPlayer);
 ```
+
+#### StarMapAfterSave
+
+Namespace: `StarMap.API`  
+Assembly: `StarMap.API`  
+Target: Method
+
+Methods marked with this attribute will be called after KSA has written a save, with the directory
+it was written to. A mod that keeps per-save state can write its own file beside `universe.xml`.
+
+```csharp
+[StarMapAfterSave]
+public void ModMethod(System.IO.DirectoryInfo saveDirectory);
+```
+
+#### StarMapAfterLoad
+
+Namespace: `StarMap.API`  
+Assembly: `StarMap.API`  
+Target: Method
+
+Methods marked with this attribute will be called after KSA has loaded a save, with the directory
+it was read from.
+
+```csharp
+[StarMapAfterLoad]
+public void ModMethod(System.IO.DirectoryInfo saveDirectory);
+```

--- a/StarMap.API/SaveAttributes.cs
+++ b/StarMap.API/SaveAttributes.cs
@@ -17,8 +17,7 @@ namespace StarMap.API
     /// <list type="bullet">
     ///   <item>
     ///     <description>
-    ///       <paramref name="saveDirectory"/> is the folder the save was written to, so a mod can
-    ///       put its own file beside <c>universe.xml</c>.
+    ///       <paramref name="saveDirectory"/> is the folder the save was written to.
     ///     </description>
     ///   </item>
     /// </list>
@@ -53,8 +52,7 @@ namespace StarMap.API
     /// <list type="bullet">
     ///   <item>
     ///     <description>
-    ///       <paramref name="saveDirectory"/> is the folder the save was read from, so a mod can
-    ///       read its own file from beside <c>universe.xml</c>.
+    ///       <paramref name="saveDirectory"/> is the folder the save was read from.
     ///     </description>
     ///   </item>
     /// </list>

--- a/StarMap.API/SaveAttributes.cs
+++ b/StarMap.API/SaveAttributes.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using System.Reflection;
+
+namespace StarMap.API
+{
+    /// <summary>
+    /// Methods marked with this attribute will be called after KSA has written a save.
+    /// </summary>
+    /// <remarks>
+    /// Methods using this attribute must match the following signature:
+    ///
+    /// <code>
+    /// public void MethodName(System.IO.DirectoryInfo saveDirectory);
+    /// </code>
+    ///
+    /// Parameter requirements:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///       <paramref name="saveDirectory"/> is the folder the save was written to, so a mod can
+    ///       put its own file beside <c>universe.xml</c>.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    ///
+    /// Requirements:
+    /// <list type="bullet">
+    ///   <item><description>Return type must be <see cref="void"/>.</description></item>
+    ///   <item><description>Method must be an instance method (non-static).</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed class StarMapAfterSaveAttribute : StarMapMethodAttribute
+    {
+        public override bool IsValidSignature(MethodInfo method)
+        {
+            return method.ReturnType == typeof(void) &&
+                   method.GetParameters().Length == 1 &&
+                   method.GetParameters()[0].ParameterType == typeof(DirectoryInfo);
+        }
+    }
+
+    /// <summary>
+    /// Methods marked with this attribute will be called after KSA has loaded a save.
+    /// </summary>
+    /// <remarks>
+    /// Methods using this attribute must match the following signature:
+    ///
+    /// <code>
+    /// public void MethodName(System.IO.DirectoryInfo saveDirectory);
+    /// </code>
+    ///
+    /// Parameter requirements:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///       <paramref name="saveDirectory"/> is the folder the save was read from, so a mod can
+    ///       read its own file from beside <c>universe.xml</c>.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    ///
+    /// Requirements:
+    /// <list type="bullet">
+    ///   <item><description>Return type must be <see cref="void"/>.</description></item>
+    ///   <item><description>Method must be an instance method (non-static).</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed class StarMapAfterLoadAttribute : StarMapMethodAttribute
+    {
+        public override bool IsValidSignature(MethodInfo method)
+        {
+            return method.ReturnType == typeof(void) &&
+                   method.GetParameters().Length == 1 &&
+                   method.GetParameters()[0].ParameterType == typeof(DirectoryInfo);
+        }
+    }
+}

--- a/StarMap.Core/Patches/UniverseDataPatcher.cs
+++ b/StarMap.Core/Patches/UniverseDataPatcher.cs
@@ -6,12 +6,7 @@ using StarMap.API;
 namespace StarMap.Core.Patches
 {
     /// <summary>
-    /// Tells mods when a save is written or read, and where.
-    ///
-    /// A save is a directory, so a mod that keeps per-save state can put a file beside
-    /// universe.xml. Without a hook the only way to notice is to poll that file's timestamp,
-    /// which leaves a window: save and load inside it and the mod writes nothing for that save,
-    /// then writes over it afterwards.
+    /// Tells mods when a save is written or read, and which directory it is in.
     /// </summary>
     [HarmonyPatch(typeof(UniverseData))]
     internal static class UniverseDataPatcher

--- a/StarMap.Core/Patches/UniverseDataPatcher.cs
+++ b/StarMap.Core/Patches/UniverseDataPatcher.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using HarmonyLib;
+using KSA;
+using StarMap.API;
+
+namespace StarMap.Core.Patches
+{
+    /// <summary>
+    /// Tells mods when a save is written or read, and where.
+    ///
+    /// A save is a directory, so a mod that keeps per-save state can put a file beside
+    /// universe.xml. Without a hook the only way to notice is to poll that file's timestamp,
+    /// which leaves a window: save and load inside it and the mod writes nothing for that save,
+    /// then writes over it afterwards.
+    /// </summary>
+    [HarmonyPatch(typeof(UniverseData))]
+    internal static class UniverseDataPatcher
+    {
+        private const string WriteToMethodName = "WriteTo";
+        private const string LoadFromMethodName = "LoadFrom";
+
+        // WriteTo is overloaded; the DirectoryInfo one is the save on disk.
+        [HarmonyPatch(WriteToMethodName, [typeof(DirectoryInfo)])]
+        [HarmonyPostfix]
+        public static void AfterWriteTo(DirectoryInfo directory)
+        {
+            var methods = StarMapCore.Instance?.Loader.ModRegistry.Get<StarMapAfterSaveAttribute>() ?? [];
+
+            foreach (var (_, @object, method) in methods)
+            {
+                method.Invoke(@object, [directory]);
+            }
+        }
+
+        [HarmonyPatch(LoadFromMethodName)]
+        [HarmonyPostfix]
+        public static void AfterLoadFrom(UncompressedSave uncompressedSave)
+        {
+            var methods = StarMapCore.Instance?.Loader.ModRegistry.Get<StarMapAfterLoadAttribute>() ?? [];
+
+            foreach (var (_, @object, method) in methods)
+            {
+                method.Invoke(@object, [uncompressedSave.Directory]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The problem

A mod that keeps per-save state has no way to be told when a save happens. There is no save or load hook, and neither `Universe`, `Program` nor `GameSaves` raises an event, so the only signal available is polling the timestamp of `universe.xml`.

Polling leaves a window. Save and load inside it and the mod writes nothing for that save, and then — when the poll finally fires and sees the stamp change — writes the freshly-defaulted state over the file. Shortening the interval narrows the window without closing it, and costs a file stat every frame to do so.

I hit this in a mod that stores per-craft settings inside the save folder, which is where they belong: deleting a save deletes them, copying copies them, renaming takes them along.

## The change

Two attributes, following the existing ones:

```csharp
[StarMapAfterSave]
public void OnSaved(DirectoryInfo saveDirectory);

[StarMapAfterLoad]
public void OnLoaded(DirectoryInfo saveDirectory);
```

Both pass the save's directory, because a save *is* a directory and what a mod usually wants is to put a file beside `universe.xml`.

Patched on `UniverseData.WriteTo(DirectoryInfo)` and `UniverseData.LoadFrom`, both public. `WriteTo` is overloaded, so the patch names the argument type.

## What I could not verify

The repository pins `RocketWerkz.KSA.Ref` 2026.7.6.4939, which is not on nuget.org, so I could not restore it. I compiled `StarMap.API` cleanly and type-checked `StarMap.Core` against **KSA 2026.8.5.5168** from a local install — with that build, the pre-existing `ConfirmRestart*` files do not compile (`PopupButton`/`IPopupWidget` and `DrawUi` have moved), which is unrelated to this change but did stop a full solution build here.

So: **the method shapes are worth a second look against the pinned build**, and this is a draft rather than ready to merge for that reason. If `WriteTo`/`LoadFrom` differ in 2026.7.6.4939, the patch targets need adjusting.
